### PR TITLE
[fix] Separate Go and Python dependencies for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM golang:1.16-alpine AS builder
 RUN apk add --update make git protoc protobuf protobuf-dev curl
 COPY . /home/${GITHUB_PATH}
 WORKDIR /home/${GITHUB_PATH}
-RUN make deps && make build
+RUN make deps-go && make build-go
 
 # gRPC Server
 

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -6,7 +6,7 @@ FROM golang:1.16-alpine AS builder
 RUN apk add --update make git protoc protobuf protobuf-dev curl
 COPY . /home/${GITHUB_PATH}
 WORKDIR /home/${GITHUB_PATH}
-RUN make deps && make build
+RUN make deps-go && make build-go
 
 RUN go get github.com/go-delve/delve/cmd/dlv
 

--- a/buf.gen.python.yaml
+++ b/buf.gen.python.yaml
@@ -1,15 +1,11 @@
 version: v1
 plugins:
-  - name: go
-    out: pkg/omp-template-api
-    opt:
-      - paths=import
+  - name: python
+    out: pypkg/omp-template-api
     strategy: directory
 
-  - name: go-grpc
-    out: pkg/omp-template-api
-    opt:
-      - paths=import
+  - name: grpclib_python
+    out: pypkg/omp-template-api
     strategy: directory
 
   - name: grpc-gateway


### PR DESCRIPTION
В сборке build контейнера присутствовали команды make deps и build, которые в свою очередь требовали наличия python в контейнере и генерировали пакет под python. Контейнер не собирался и, соответственно, не поднимался.

Был рассмотрен путь решения - занесение python в build контейнер, но это кратно увеличило время сборки контейнера - видимо, это особенности alpine - https://habr.com/ru/post/486202/.

Как итог - т.к. пакет под python не является необходимым для функционирования контейнера и может быть сгенерирован разработчиком локально и добавлен в git до коммита - решено разделить пути Go и Python - тем самым освободив контейнер Docker от лишних зависимостей.

Альтернативное решение - попробовать перевезти образы с alpine на debian или ubuntu.