### PR TITLE
Docker cache deps-go

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,14 @@
 ARG GITHUB_PATH=github.com/ozonmp/omp-template-api
 
 FROM golang:1.16-alpine AS builder
-RUN apk add --update make git protoc protobuf protobuf-dev curl
-COPY . /home/${GITHUB_PATH}
+
 WORKDIR /home/${GITHUB_PATH}
-RUN make deps-go && make build-go
+
+RUN apk add --update make git protoc protobuf protobuf-dev curl
+COPY Makefile Makefile
+RUN make deps-go
+COPY . .
+RUN make build-go
 
 # gRPC Server
 

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -3,10 +3,14 @@
 ARG GITHUB_PATH=github.com/ozonmp/omp-template-api
 
 FROM golang:1.16-alpine AS builder
-RUN apk add --update make git protoc protobuf protobuf-dev curl
-COPY . /home/${GITHUB_PATH}
+
 WORKDIR /home/${GITHUB_PATH}
-RUN make deps-go && make build-go
+
+RUN apk add --update make git protoc protobuf protobuf-dev curl
+COPY Makefile Makefile
+RUN make deps-go
+COPY . .
+RUN make build-go
 
 RUN go get github.com/go-delve/delve/cmd/dlv
 


### PR DESCRIPTION
`make deps-go` скачивает команды через `go install`. Вместо того чтобы при билде всегда устанавливать зависимости их можно выполнить в отдельной `RUN` команде, чтобы закешировать.