### PR TITLE
[fix] Simplified the buf installing by move create dirs to curl command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,7 @@ generate-go: .generate-install-buf .generate-go .generate-finalize-go
 
 .generate-install-buf:
 	@ command -v buf 2>&1 > /dev/null || (echo "Install buf" && \
-    		mkdir -p "$(GO_BIN)" && \
-    		curl -sSL0 https://github.com/bufbuild/buf/releases/download/$(BUF_VERSION)/buf-$(OS_NAME)-$(OS_ARCH)$(shell go env GOEXE) -o "$(BUF_EXE)" && \
+    		curl -sSL0 https://github.com/bufbuild/buf/releases/download/$(BUF_VERSION)/buf-$(OS_NAME)-$(OS_ARCH)$(shell go env GOEXE) --create-dirs -o "$(BUF_EXE)" && \
     		chmod +x "$(BUF_EXE)")
 
 .generate-go:


### PR DESCRIPTION
У одного из студентов под Windows было замечено некорректное поведение mkdir -p при билде контейнера builder. Предполагаю, что, возможно - docker для оптимизации может использовать mkdir из родительской системы, а там если не включены расширения в Windows - то команда по умолчанию не создает рекурсивно директории. Но это только предположения. В любом случае - проблема у студента исчезла после применения изменений PR.

PR использует опцию curl для рекурсивного создания директорий. В текущей локальной ситуации - данный подход уместен, т.к. mkdir был нужен только для curl.