### PR TITLE
zerolog default level trace

### DIFF
--- a/cmd/grpc-server/main.go
+++ b/cmd/grpc-server/main.go
@@ -38,9 +38,10 @@ func main() {
 		Str("environment", cfg.Project.Environment).
 		Msgf("Starting service: %s", cfg.Project.Name)
 
-	// default: zerolog.SetGlobalLevel(zerolog.InfoLevel)
 	if cfg.Project.Debug {
 		zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	} else {
+		zerolog.SetGlobalLevel(zerolog.InfoLevel)
 	}
 
 	dsn := fmt.Sprintf("host=%v port=%v user=%v password=%v dbname=%v sslmode=%v",


### PR DESCRIPTION
Если я правильно понял смысл этого кода, что у нас по умолчанию InfoLevel чтобы не спамить. Через конфиг мы можем включить DebugLevel. Тогда это не работает так как там по умолчанию TraceLevel который включает в себя все.
Вот тут https://github.com/rs/zerolog/blob/master/ctx.go